### PR TITLE
fix: #90 disable turbopackMinify in production for template editor

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -6,6 +6,7 @@ const nextConfig: NextConfig = {
   serverExternalPackages: ['@react-pdf/renderer', 'react-pdf-html'],
   experimental: {
     inlineCss: true,
+    turbopackMinify: false,
   },
 };
 


### PR DESCRIPTION
## Summary
- Disables `turbopackMinify` in production to sidestep the template editor DnD bug

Closes #90